### PR TITLE
feat: persist note widget position across sessions

### DIFF
--- a/src/content/content_ui.js
+++ b/src/content/content_ui.js
@@ -511,14 +511,26 @@
         const baseCleanup = widget._lcNotesCleanup;
         const extraCleanupFns = [];
 
-        // --- THEME LOGIC ---
+        // --- THEME & POSITION LOGIC ---
         if (typeof chrome !== 'undefined' && chrome.runtime?.id && chrome.storage && chrome.storage.local) {
             const syncWidgetTheme = () => new Promise((resolve) => {
                 try {
                     if (!chrome.runtime?.id) { resolve(); return; }
-                    chrome.storage.local.get({ theme: 'sakura' }, (result) => {
+                    chrome.storage.local.get(['theme', 'notesWidgetPosition'], (result) => {
                         if (!chrome.runtime?.lastError) {
                             applyNotesWidgetTheme(widget, result.theme || 'sakura');
+
+                            // Apply stored position if exists
+                            if (result.notesWidgetPosition) {
+                                const { left, top } = result.notesWidgetPosition;
+                                // Basic bounds check to ensure it's not off-screen
+                                const safeLeft = Math.max(0, Math.min(left, window.innerWidth - 50));
+                                const safeTop = Math.max(0, Math.min(top, window.innerHeight - 50));
+                                
+                                widget.style.right = 'auto';
+                                widget.style.top = `${safeTop}px`;
+                                widget.style.left = `${safeLeft}px`;
+                            }
                         }
                         resolve();
                     });
@@ -937,6 +949,17 @@
                 container.classList.remove('dragging');
                 handle.dataset.justDragged = 'true';
                 setTimeout(() => { handle.dataset.justDragged = 'false'; }, 50);
+
+                // Save new position
+                if (typeof chrome !== 'undefined' && chrome.runtime?.id && chrome.storage && chrome.storage.local) {
+                    const rect = container.getBoundingClientRect();
+                    chrome.storage.local.set({
+                        notesWidgetPosition: {
+                            left: rect.left,
+                            top: rect.top
+                        }
+                    });
+                }
             }
         };
 


### PR DESCRIPTION
## Why
Currently, while the note widget is draggable, it does not persist its coordinates. Every time a LeetCode page is refreshed or revisited, the widget resets to its default starting position. This is often inconvenient as the default placement can obstruct UI elements, such as the "Reset to the default code definition" button.

## What
This PR enables the note widget to "remember" its last dragged position by persisting its coordinates.

1. Added logic to save the widget's position upon the end of a drag event.
2. Added logic to retrieve and apply the saved position when the widget initializes.


## Tests
I have verified this change locally by:
1. Building the project and loading the unpacked extension in Chrome.
3. Dragging the note widget to various areas of the screen.
4. Refreshing the page and navigating between different LeetCode problems.

Result: The widget consistently rendered at the last saved position.

